### PR TITLE
Add support of /run_ci command in merge request note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,17 @@ plugins:
 after that you can set gitlab webhook at project config
 ```yml
 webhooks:
+    events:
+        - Push Hook
+        - Merge Request Hook
+        - Note Hook
     gitlab:
         secret: '123456'
 ```
 plugin will listen `POST /webhooks/:projectName/gitlab` and will get secret
 from ```X-Gitlab-Token``` request header.
+
+Also plugin support force build running via adding MR comment with text `/run_ci`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,25 @@ plugins:
 after that you can set gitlab webhook at project config
 ```yml
 webhooks:
-    events:
-        - Push Hook
-        - Merge Request Hook
-        - Note Hook
     gitlab:
         secret: '123456'
 ```
 plugin will listen `POST /webhooks/:projectName/gitlab` and will get secret
 from ```X-Gitlab-Token``` request header.
 
-Also plugin supports force build running via adding MR comment with text `/run_ci`.
+By default plugin supports only GitLab `Push Hook` events to run build on new commits in default branch (specified in `scm.rev` section of project config).
+
+In order to run build on GitLab Merge Request opening or new commits in source branch add `Merge Request Hook` to `webhooks.gitlab.events` section of project config.
+
+Also plugin supports force build running via adding MR comment with text `/run_ci`. It requires `Note Hook` in `webhooks.gitlab.events` section of project config, f.e.:
+```yml
+webhooks:
+    gitlab:
+        events:
+            - Push Hook
+            - Merge Request Hook
+            - Note Hook
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ webhooks:
 plugin will listen `POST /webhooks/:projectName/gitlab` and will get secret
 from ```X-Gitlab-Token``` request header.
 
-Also plugin support force build running via adding MR comment with text `/run_ci`.
+Also plugin supports force build running via adding MR comment with text `/run_ci`.
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,14 +19,13 @@ GitlabWebhook.prototype.check = function(req, project) {
 	var events = project.webhooks[this.name].events || ['Push Hook'];
 
 	var event = req.headers['x-gitlab-event'];
-console.log(event, events)
-console.log(req.body)
+
 	return (
 		(events.indexOf(event) !== -1) &&
 		(
 			(
 				event === 'Push Hook' &&
-				req.body.ref === 'refs/heads/' + project.
+				req.body.ref === 'refs/heads/' + project.scm.rev
 			) ||
 			(
 				event === 'Merge Request Hook' &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var GitlabWebhook = function() {
 
 inherits(GitlabWebhook, BaseWebhook);
 
-GitlabWebhook.prototype.forceCiRegExp = /\[(ci[ -]force|force[ -]ci)\]/;
+GitlabWebhook.prototype.runCiRegExp = /^\s*\/run_ci\s*$/;
 
 GitlabWebhook.prototype.getSecret = function(req) {
 	return req.headers['x-gitlab-token'];
@@ -19,7 +19,8 @@ GitlabWebhook.prototype.check = function(req, project) {
 	var events = project.webhooks[this.name].events || ['Push Hook'];
 
 	var event = req.headers['x-gitlab-event'];
-
+console.log(event, events)
+console.log(req.body)
 	return (
 		(events.indexOf(event) !== -1) &&
 		(
@@ -39,10 +40,17 @@ GitlabWebhook.prototype.check = function(req, project) {
 				req.body.object_attributes.action === 'update' &&
 				req.body.object_attributes.source_branch &&
 				(
-					this.forceCiRegExp.test(req.body.object_attributes.description) ||
 					// check that mr has new commits
 					req.body.object_attributes.oldrev
 				)
+			) ||
+			(
+				event === 'Note Hook' &&
+				req.body.object_attributes &&
+				req.body.object_attributes.noteable_type === 'MergeRequest' &&
+				req.body.merge_request &&
+				req.body.merge_request.source_branch &&
+				this.runCiRegExp.test(req.body.object_attributes.note)
 			)
 		)
 	);
@@ -68,6 +76,17 @@ GitlabWebhook.prototype.createBuild = function(req, project, app) {
 
 		params.buildParams = {
 			scmRev: req.body.object_attributes.source_branch
+		};
+	} else if (event === 'Note Hook') {
+		params.initiator.mergeRequest = {
+			id: req.body.merge_request.id,
+			iid: req.body.merge_request.iid,
+			sourceProjectId: req.body.merge_request.source_project_id,
+			targetProjectId: req.body.merge_request.target_project_id
+		};
+
+		params.buildParams = {
+			scmRev: req.body.merge_request.source_branch
 		};
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ console.log(req.body)
 		(
 			(
 				event === 'Push Hook' &&
-				req.body.ref === 'refs/heads/' + project.scm.rev
+				req.body.ref === 'refs/heads/' + project.
 			) ||
 			(
 				event === 'Merge Request Hook' &&
@@ -35,14 +35,12 @@ console.log(req.body)
 				req.body.object_attributes.source_branch
 			) ||
 			(
+				// check that mr has new commits
 				event === 'Merge Request Hook' &&
 				req.body.object_attributes &&
 				req.body.object_attributes.action === 'update' &&
 				req.body.object_attributes.source_branch &&
-				(
-					// check that mr has new commits
-					req.body.object_attributes.oldrev
-				)
+				req.body.object_attributes.oldrev
 			) ||
 			(
 				event === 'Note Hook' &&


### PR DESCRIPTION
Removed `[force-ci]` support in MR description text.
Added support of running build on MR note with body `/run_ci`.
Updated readme.